### PR TITLE
Clears mutations between different source files, fixes #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Unknown
 
+### Added
+- Simply running `./bin/crytic` without any arguments will now automatically find all src files and specs
+
 ### Fixed
 - When the mutated source code fails to compile this is now being noted correctly
 

--- a/spec/generator/in_memory_generator_spec.cr
+++ b/spec/generator/in_memory_generator_spec.cr
@@ -1,0 +1,53 @@
+require "../../src/crytic/generator/in_memory_generator"
+require "../spec_helper"
+require "compiler/crystal/syntax/*"
+
+module Crytic
+  describe InMemoryMutationsGenerator do
+    describe "#mutations_for" do
+      it "returns no mutations for no possibilities" do
+        source = "#{__DIR__}/non_empty_source_file.cr"
+        specs = ["some_spec.cr"]
+
+        mutations = InMemoryMutationsGenerator
+          .new([] of Mutant::Possibilities)
+          .mutations_for(source, specs)
+
+        mutations.should be_empty
+      end
+
+      it "returns no mutations for no possibilities in the source" do
+        source = "#{__DIR__}/empty_source_file.cr"
+        specs = ["some_spec.cr"]
+
+        mutations = InMemoryMutationsGenerator.new.mutations_for(source, specs)
+
+        mutations.should be_empty
+      end
+
+      it "returns a single mutation for the number literal" do
+        source = "#{__DIR__}/non_empty_source_file.cr"
+        specs = ["some_spec.cr"]
+
+        mutations = InMemoryMutationsGenerator
+          .new([Mutant::NumberLiteralSignFlipPossibilities.new] of Mutant::Possibilities)
+          .mutations_for(source, specs)
+
+        mutations.size.should eq 1
+      end
+
+      it "doesn't mix mutations for multiple sources" do
+        source = "#{__DIR__}/non_empty_source_file.cr"
+        specs = ["some_spec.cr"]
+
+        generator = InMemoryMutationsGenerator
+          .new([Mutant::NumberLiteralSignFlipPossibilities.new] of Mutant::Possibilities)
+
+        generator.mutations_for(source, specs)
+        mutations = generator.mutations_for(source, specs)
+
+        mutations.size.should eq 1
+      end
+    end
+  end
+end

--- a/spec/generator/non_empty_source_file.cr
+++ b/spec/generator/non_empty_source_file.cr
@@ -1,0 +1,3 @@
+def foo
+  1
+end

--- a/src/crytic/generator/in_memory_generator.cr
+++ b/src/crytic/generator/in_memory_generator.cr
@@ -1,30 +1,37 @@
+require "../mutant/**"
+require "../mutation/mutation"
 require "./generator"
+require "compiler/crystal/syntax/*"
 
 module Crytic
   class InMemoryMutationsGenerator < Generator
-    MUTANT_POSSIBILITIES = [
-      Mutant::AndOrSwapPossibilities.new,
-      Mutant::BoolLiteralFlipPossibilities.new,
-      Mutant::ConditionFlipPossibilities.new,
-      Mutant::NumberLiteralChangePossibilities.new,
-      Mutant::NumberLiteralSignFlipPossibilities.new,
-      Mutant::StringLiteralChangePossibilities.new,
-    ]
+    def initialize(@possibilities = [
+                     Mutant::AndOrSwapPossibilities.new,
+                     Mutant::BoolLiteralFlipPossibilities.new,
+                     Mutant::ConditionFlipPossibilities.new,
+                     Mutant::NumberLiteralChangePossibilities.new,
+                     Mutant::NumberLiteralSignFlipPossibilities.new,
+                     Mutant::StringLiteralChangePossibilities.new,
+                   ] of Mutant::Possibilities)
+    end
 
     def mutations_for(source : String, specs : Array(String))
       ast = Crystal::Parser.parse(File.read(source))
 
-      MUTANT_POSSIBILITIES.map do |inspector|
-        ast.accept(inspector)
-        inspector
-      end.select(&.any?).map do |inspector|
-        inspector.locations.map do |location|
-          Mutation::Mutation
-            .with(mutant: inspector.mutant_class.at(location: location),
-            original: source,
-            specs: specs)
+      @possibilities.each(&.reset)
+      @possibilities
+        .map do |inspector|
+          ast.accept(inspector)
+          inspector
         end
-      end.flatten
+        .select(&.any?)
+        .map do |inspector|
+          inspector.locations.map do |location|
+            Mutation::Mutation
+              .with(inspector.mutant_class.at(location), source, specs)
+          end
+        end
+        .flatten
     end
   end
 end

--- a/src/crytic/mutant/possibilities.cr
+++ b/src/crytic/mutant/possibilities.cr
@@ -15,6 +15,10 @@ module Crytic::Mutant
       @locations.size > 0
     end
 
+    def reset
+      @locations = [] of Crystal::Location
+    end
+
     def visit(node : Crystal::ASTNode)
       true
     end

--- a/src/crytic/mutation/mutation.cr
+++ b/src/crytic/mutation/mutation.cr
@@ -5,7 +5,6 @@ require "../process_runner"
 require "../source"
 require "./inject_mutated_subject_into_specs"
 require "./result"
-require "compiler/crystal/syntax/*"
 
 module Crytic::Mutation
   # Represents a single mutation to a single source file
@@ -21,6 +20,12 @@ module Crytic::Mutation
       source = Source.new(subject_source)
       mutated_source = source.mutated_source(@mutant)
       source_diff = Crytic::Diff.unified_diff(source.original_source, mutated_source).to_s
+
+      if source_diff.empty?
+        puts "this mutation did not produce a diff"
+        pp @mutant
+        return Result.new(Status::Uncovered, @mutant, source_diff)
+      end
 
       process_result = run_mutation(mutated_source)
       success_messages_in_output = /Finished/ =~ process_result[:output]

--- a/src/crytic/mutation/mutation.cr
+++ b/src/crytic/mutation/mutation.cr
@@ -21,12 +21,6 @@ module Crytic::Mutation
       mutated_source = source.mutated_source(@mutant)
       source_diff = Crytic::Diff.unified_diff(source.original_source, mutated_source).to_s
 
-      if source_diff.empty?
-        puts "this mutation did not produce a diff"
-        pp @mutant
-        return Result.new(Status::Uncovered, @mutant, source_diff)
-      end
-
       process_result = run_mutation(mutated_source)
       success_messages_in_output = /Finished/ =~ process_result[:output]
       status = if process_result[:exit_code] == ProcessRunner::SUCCESS

--- a/src/crytic/runner.cr
+++ b/src/crytic/runner.cr
@@ -1,7 +1,5 @@
 require "./generator/**"
 require "./msi_calculator"
-require "./mutant/**"
-require "./mutation/mutation"
 require "./mutation/no_mutation"
 require "./reporter/**"
 require "./source"


### PR DESCRIPTION
Since the "Possibilities" hold local state to record all the possible
mutation locations, those need to be cleared when firing it with
multiple different source files. Otherwise it reports all previous
possibilities for entirely different source files as well 🙊

- [x] Changelog