### PR TITLE
Hk issue 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Unknown
 
+### Fixed
+
+- Due to a regression introduced in 5a02821cce6bd27361bc84d5b073b21dc2fa55f0, require statements that don't yield any files could be left in the mutated code, leading to compile errors which looked like killed mutants
+
 ## [3.2.1] - 2019-01-15
 
 ### Fixed

--- a/fixtures/require_wildcards/app.cr
+++ b/fixtures/require_wildcards/app.cr
@@ -1,0 +1,1 @@
+require "./folder/nested/**"

--- a/fixtures/require_wildcards/folder/nested/.keep
+++ b/fixtures/require_wildcards/folder/nested/.keep
@@ -1,0 +1,1 @@
+keepfile

--- a/fixtures/require_wildcards/foo.cr
+++ b/fixtures/require_wildcards/foo.cr
@@ -1,0 +1,3 @@
+require "./app.cr"
+
+puts "hi"

--- a/fixtures/require_wildcards/foo_spec.cr
+++ b/fixtures/require_wildcards/foo_spec.cr
@@ -1,0 +1,8 @@
+require "./foo"
+require "spec"
+
+describe "foo" do
+  it "always passes" do
+    true.should eq true
+  end
+end

--- a/spec/mutation/inject_mutated_subject_into_specs_spec.cr
+++ b/spec/mutation/inject_mutated_subject_into_specs_spec.cr
@@ -90,5 +90,31 @@ module Crytic::Mutation
 
         CODE
     end
+
+    it "replaces requires that don't yield any files" do
+      spec_file = "./fixtures/require_wildcards/foo_spec.cr"
+      subject_file = "./fixtures/require_wildcards/foo.cr"
+      InjectMutatedSubjectIntoSpecs
+        .new(
+        path: spec_file,
+        source: File.read(spec_file),
+        subject_path: subject_file,
+        mutated_subject_source: File.read(subject_file))
+        .to_mutated_source
+        .should eq <<-CODE
+        # require of `fixtures/require_wildcards/foo.cr` from `fixtures/require_wildcards/foo_spec.cr`
+        # require of `fixtures/require_wildcards/app.cr` from `fixtures/require_wildcards/foo.cr`
+
+        puts("hi")
+
+        require "spec"
+        describe("foo") do
+          it("always passes") do
+            true.should(eq(true))
+          end
+        end
+
+        CODE
+    end
   end
 end

--- a/src/crytic/mutation/inject_mutated_subject_into_specs.cr
+++ b/src/crytic/mutation/inject_mutated_subject_into_specs.cr
@@ -121,9 +121,9 @@ module Crytic::Mutation
 
           list_of_required_file << required_file
         end
-
-        node.string = "$#{idx}"
       end
+
+      node.string = "$#{idx}"
 
       false
     end

--- a/src/crytic/mutation/inject_mutated_subject_into_specs.cr
+++ b/src/crytic/mutation/inject_mutated_subject_into_specs.cr
@@ -91,7 +91,7 @@ module Crytic::Mutation
     # Then on finalization, we replace each require "xxx" by the proper file.
     def visit(node : Crystal::Require)
       file = node.string
-      return false unless file[0] == '.'
+      return false unless file.starts_with?(".")
 
       current_directory = InjectMutatedSubjectIntoSpecs.relative_path_to_project(File.dirname(@path))
       new_files_to_load = find_in_path_relative_to_dir(file, current_directory)


### PR DESCRIPTION
Fixes #37. That one took me three days of looking at and thinking about and 1 second to fixed once I had it reproduced lol. Due to less than ideal coverage of the "inject subject into specs file", I accidentally moved the `node.string = "${idx}"` _into_ the load files loop, meaning the require string was not replaced if the weren't any files to load. This in turn lead to a compile error when running crytic on my blog, which is somehow masked because compile errors appear to be killed mutants. I think I will output any compile errors even for killed mutants, because only like this was I able to spot the bug.