### PR TITLE
Closes #39. Modify StringLiteralChangeMutant to be more efficient.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - When no mutations were run, crytic now exits with 1 instead of 0
+- The `StringLiteralChange` mutant now performs more efficient replacements
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ This mutant changes the sign of literal numbers. It ignores literal "0". A typic
 
 #### StringLiteralChange
 
-This mutant changes literal occurances of string by appending the string `__crytic__`. A typical mutation is:
+This mutant changes literal occurances of string by replacing empty strings with `__crytic__` and all other strings with the empty string. Typical mutations are:
 
 ```diff
 - "Welcome"
-+ "Welcome__crytic__"
++ ""
 ```
 
 #### AnyAllSwap

--- a/spec/mutant/string_literal_change_spec.cr
+++ b/spec/mutant/string_literal_change_spec.cr
@@ -3,12 +3,20 @@ require "../spec_helper"
 
 module Crytic
   describe Mutant::StringLiteralChange do
-    it "appends to string litereals" do
+    it "changes to the empty string for non-empty strings" do
       ast = Crystal::Parser.parse("\"hi there\"")
       ast.accept(Mutant::StringLiteralChange.at(location_at(
         line_number: 1,
         column_number: 1)))
-      ast.to_s.should eq "\"hi there__crytic__\""
+      ast.to_s.should eq "\"\""
+    end
+
+    it "changes empty strings to __crytic__" do
+      ast = Crystal::Parser.parse("\"\"")
+      ast.accept(Mutant::StringLiteralChange.at(location_at(
+        line_number: 1,
+        column_number: 1)))
+      ast.to_s.should eq "\"__crytic__\""
     end
 
     it "only applies to location" do

--- a/src/crytic/mutant/string_literal_change.cr
+++ b/src/crytic/mutant/string_literal_change.cr
@@ -5,7 +5,11 @@ module Crytic::Mutant
   class StringLiteralChange < VisitorMutant
     def visit(node : Crystal::StringLiteral)
       if @location.matches?(node)
-        node.value = "#{node.value}__crytic__"
+        node.value = if node.value.empty?
+                       "__crytic__"
+                     else
+                       ""
+                     end
       end
       true
     end


### PR DESCRIPTION
Instead of appending a string, which is often not caught by a
test-suite, replace the string by "" or "__crytic__". This should be of
much more value.