### PR TITLE
When a neutral mutation errors, print the actual error as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New "File Summary" reporter that list the covered subjects and the number of mutations that were performed on each of those files respectively
+- When the neutral mutation errored, the output is shown as well
 
 ### Changed
 

--- a/spec/fake_mutation.cr
+++ b/spec/fake_mutation.cr
@@ -18,6 +18,6 @@ class FakeMutation < Crytic::Mutation::Mutation
 
   def run
     @run_call_count += 1
-    Crytic::Mutation::Result.new(@reported_status, irrelevant_mutant, "")
+    Crytic::Mutation::Result.new(@reported_status, irrelevant_mutant, "", "")
   end
 end

--- a/spec/fake_process_runner.cr
+++ b/spec/fake_process_runner.cr
@@ -4,6 +4,7 @@ module Crytic
   class FakeProcessRunner < ProcessRunner
     property exit_code : Array(Int32) = [0, 0]
     property timeout = [] of Time::Span
+    property errors = [] of IO
     @cmd = [] of String
     @args = [] of String
     @output_io = IO::Memory.new
@@ -16,6 +17,7 @@ module Crytic
       @cmd << cmd
       @args << args.join(" ")
       output << @output_io.to_s
+      errors << error
       exit_code.shift
     end
 

--- a/spec/reporter/io_reporter_spec.cr
+++ b/spec/reporter/io_reporter_spec.cr
@@ -63,11 +63,12 @@ module Crytic::Reporter
       it "prints a helpful message indicating that the mutant injecting setup seems to have broken the suite" do
         io = IO::Memory.new
 
-        IoReporter.new(io).report_neutral_result(result(Mutation::Status::Errored))
+        IoReporter.new(io).report_neutral_result(result(Mutation::Status::Errored, output: "the actual error"))
 
         io.to_s.should contain "NumberLiteralChange"
         io.to_s.should contain "some_filename.cr\n"
         io.to_s.should contain "There was an error"
+        io.to_s.should contain "the actual error"
       end
 
       it "is silent for a neutral mutation that didnt error" do

--- a/spec/reporter/stryker_badge_reporter_spec.cr
+++ b/spec/reporter/stryker_badge_reporter_spec.cr
@@ -52,8 +52,5 @@ private def fake_env
 end
 
 private def results
-  Crytic::Mutation::ResultSet.new([Crytic::Mutation::Result.new(
-                                     status: Crytic::Mutation::Status::Covered,
-                                     mutant: fake_mutant,
-                                     diff: "")])
+  Crytic::Mutation::ResultSet.new([result])
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -29,11 +29,12 @@ def ast_from(code)
   Crystal::Parser.parse(code)
 end
 
-def result(status = Crytic::Mutation::Status::Covered, filename = "some_filename.cr")
+def result(status = Crytic::Mutation::Status::Covered, filename = "some_filename.cr", output = "")
   Crytic::Mutation::Result.new(
     status: status,
     mutant: fake_mutant(filename),
-    diff: "diff")
+    diff: "diff",
+    output: output)
 end
 
 def erroring_mutation

--- a/src/crytic/mutation/isolated_mutation.cr
+++ b/src/crytic/mutation/isolated_mutation.cr
@@ -28,7 +28,7 @@ module Crytic::Mutation
                  Status::Covered
                end
 
-      Result.new(status, @environment.mutant, subject.diff)
+      Result.new(status, @environment.mutant, subject.diff, process_result[:output])
     end
 
     def self.with(environment)
@@ -39,7 +39,6 @@ module Crytic::Mutation
     end
 
     private def run(mutated_source : SourceCode)
-      io = IO::Memory.new
       tempfile_path = write_full_source_into_tempfile(mutated_source)
       res = compile_tempfile_into_binary(tempfile_path)
 
@@ -49,6 +48,7 @@ module Crytic::Mutation
       end
 
       binary = res[:binary]
+      io = IO::Memory.new
       exit_code = execute_binary(binary, io)
       remove_artifacts(tempfile_path, binary)
 
@@ -73,7 +73,7 @@ module Crytic::Mutation
 
     private def execute_binary(binary, io)
       @environment
-        .execute(binary, [] of String, output: io, error: STDERR, timeout: 10.seconds)
+        .execute(binary, [] of String, output: io, error: io, timeout: 10.seconds)
     end
 
     private def remove_artifacts(tempfile_path, binary)

--- a/src/crytic/mutation/result.cr
+++ b/src/crytic/mutation/result.cr
@@ -8,7 +8,11 @@ module Crytic::Mutation
     Uncovered
   end
 
-  record Result, status : Status, mutant : Mutant::Mutant, diff : String do
+  record Result,
+    status : Status,
+    mutant : Mutant::Mutant,
+    diff : String,
+    output : String do
     delegate uncovered?, covered?, errored?, timeout?, to: status
 
     def mutant_name

--- a/src/crytic/reporter/io_reporter.cr
+++ b/src/crytic/reporter/io_reporter.cr
@@ -32,8 +32,9 @@ module Crytic::Reporter
         @io << "\n#{INDENT}🚧 #{result.mutant_name}"
         @io << "\n#{INDENT + INDENT}in #{result.location.filename}"
         @io << <<-HELP
-        \n#{INDENT + INDENT}There was an error running the test-suite using crytic's infrastructure with the unmodified subject.\n#{INDENT + INDENT}This is very likely a bug in crytic, please go ahead and file an\n#{INDENT + INDENT}issue at https://github.com/hanneskaeufler/crytic/issues. There are a number of known limitations already which\n#{INDENT + INDENT}could be the reason for the error, see https://github.com/hanneskaeufler/crytic/issues/19.
+        \n#{INDENT + INDENT}There was an error running the test-suite using crytic's infrastructure with the unmodified subject.\n#{INDENT + INDENT}This is very likely a bug in crytic, please go ahead and file an\n#{INDENT + INDENT}issue at https://github.com/hanneskaeufler/crytic/issues. There are a number of known limitations already which\n#{INDENT + INDENT}could be the reason for the error, see https://github.com/hanneskaeufler/crytic/issues/19.\n
         HELP
+        @io << "#{INDENT + INDENT + INDENT} #{result.output}"
       end
     end
 


### PR DESCRIPTION
Because I have no clue whats going on here: https://circleci.com/gh/hanneskaeufler/crytic/730?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link